### PR TITLE
Standardising DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -59,7 +59,7 @@
 			"category": "contact",
 			"values": [
 				{
-					"value": "Jennifer Tremblay-Mercier, Research Co-ordinator, jennifer.tremblay-mercier@douglas.mcgill.ca, 514-761-6131 #3329"
+					"value": "A. Vania Apkarian, Director Center for Translational Pain Research, Northwestern University, Feinberg School of Medicine, a-apkarian@northwestern.edu"
 				}
 			]
 		},

--- a/DATS.json
+++ b/DATS.json
@@ -1,6 +1,6 @@
 {
     "title": "OpenPain subacute_longitudinal_study",
-    "description": "This dataset represents a 5 year longitudinal study of transition to chronic back pain. 70 patients with subacute back pain were tracked from 2-16 weeks after injury (interview visit) for approximately one year later, with a subset also returning for a follow up visit approximately 2-3 years after pain onset. MRI scans and behavioral data were collected across 4 visits (or 5 in the case of 2-3 year follow up). Genetic data was additionally collected at study entry. Subjects all had been pain free for one year prior to their subacute pain episode, had no history of psychiatric illness or depression, were right handed, and at least 18 years old. Over the course of the study a subset of patients showed improvements in pain while others did not, allowing for the study of the brain and behavioral processes associated with pain persistence from a very early time point. Healthy subjects and chronic back pain patients (pain duration > 5 years) are also included as controls. Generally speaking a complete dataset for a single subject involves behavioral and genetic data at an interview visit, imaging data and behavioral data collected 2 weeks, 3 months, 6 months, 1 year and 2-3 years later. Imaging data consists of two rating tasks where subjects continuous report their pain using a finger mounted device with visual feedback, two visuomotor control tasks where subjects track an autonomously animate rating bar on a screen, a diffusion tensor imaging scan, and a T1 anatomical scan. A subset of subjects also have eyes-open resting state scans. Not all subjects have all this data available at every visit. Particularly in the case of behavioral data, subjects elected not to answer a number of questions. In some cases (e.g. medication use), this might be interpreted to mean that they had no relevant information to provide, but in other cases it may mean that the subject simply ommitted an answer by accident. In all cases, missing data is indicated by an n/a entry, but we leave it up to others to interpret these as they see fit",
+    "description": "This dataset represents a 5 year longitudinal study of transition to chronic back pain. 70 patients with subacute back pain were tracked from 2-16 weeks after injury (interview visit) for approximately one year later, with a subset also returning for a follow up visit approximately 2-3 years after pain onset. MRI scans and behavioral data were collected across 4 visits (or 5 in the case of 2-3 year follow up). Genetic data was additionally collected at study entry. Subjects all had been pain free for one year prior to their subacute pain episode, had no history of psychiatric illness or depression, were right handed, and at least 18 years old. Over the course of the study a subset of patients showed improvements in pain while others did not, allowing for the study of the brain and behavioral processes associated with pain persistence from a very early time point. Healthy subjects and chronic back pain patients (pain duration > 5 years) are also included as controls. Generally speaking a complete dataset for a single subject involves behavioral and genetic data at an interview visit, imaging data and behavioral data collected 2 weeks, 3 months, 6 months, 1 year and 2-3 years later. Imaging data consists of two rating tasks where subjects continuous report their pain using a finger mounted device with visual feedback, two visuomotor control tasks where subjects track an autonomously animate rating bar on a screen, a diffusion tensor imaging scan, and a T1 anatomical scan. A subset of subjects also have eyes-open resting state scans. Not all subjects have all this data available at every visit. Particularly in the case of behavioral data, subjects elected not to answer a number of questions. In some cases (e.g. medication use), this might be interpreted to mean that they had no relevant information to provide, but in other cases it may mean that the subject simply omitted an answer by accident. In all cases, missing data is indicated by an n/a entry, but we leave it up to others to interpret these as they see fit",
     
     "creators": [
         {
@@ -15,7 +15,21 @@
         { 
             "value": "fMRI"
         }
-    ],
+    ], 
+    "distributions": [
+	        {
+			"formats": [
+				"NIfTI"
+            		],
+			"size" : 117,
+		        "unit" : {
+            			"value": "GB"
+		        },
+			"access": {
+				"landingPage": "https://www.openpain.org/"
+			}
+		}
+	],
     "version": "1.0",
     "privacy": "Open Access",
     "isAbout": [
@@ -32,7 +46,40 @@
                     "value": "2607"
                 }
             ]
-        }
-    ]
+        },
+	{
+            "category": "subjects",
+            "values": [
+                {
+                    "value": "70"
+                }
+            ]
+        },
+	{
+			"category": "contact",
+			"values": [
+				{
+					"value": "Jennifer Tremblay-Mercier, Research Co-ordinator, jennifer.tremblay-mercier@douglas.mcgill.ca, 514-761-6131 #3329"
+				}
+			]
+		},
+		{
+			"category": "files",
+			"values": [
+				{
+					"value": "7572"
+				}
+			]
+		},
+		{
+			"category": "logo",
+			"values": [
+				{
+					"value": "https://avatars3.githubusercontent.com/u/22078250?s=200&v=4"
+				}
+			]
+		}
+	]
+
 }
 


### PR DESCRIPTION
This replaces the previous closed PR #1. In addition to adding the standardised fields under distribution and extraProperties as documented in CONP-PCNO/conp-dataset#125, a typo was corrected in the description field.